### PR TITLE
Adapt plugin to GitBook 3

### DIFF
--- a/_layouts/website/page.html
+++ b/_layouts/website/page.html
@@ -1,0 +1,13 @@
+{% extends template.self %}
+
+{% block head %}
+    {{ super() }}
+    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
+    <link rel="stylesheet" href="//rawgit.com/nicgirault/angular-colorBrewer-picker/0.0.3/dist/angular-color-brewer-picker.min.css"></link>
+{% endblock %}
+
+{% block javascript %}
+    {{ super() }}
+    <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.3.15/angular.min.js"></script>
+    <script src="//raw.githack.com/nicgirault/angular-colorBrewer-picker/master/dist/angular-color-brewer-picker.min.js"></script>
+{% endblock %}

--- a/index.js
+++ b/index.js
@@ -1,9 +1,0 @@
-module.exports = {
-    // Extend website resources and html
-    website: {
-        html: {
-            "head:end": "<link rel='stylesheet' href='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css'>\n<script src='https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.3.15/angular.min.js'></script>\n<script src='https://raw.githack.com/nicgirault/angular-colorBrewer-picker/master/dist/angular-color-brewer-picker.min.js'></script>\n<link rel='stylesheet' href='https://rawgit.com/nicgirault/angular-colorBrewer-picker/0.0.3/dist/angular-color-brewer-picker.min.css'></link>"
-        }
-    }
-};
-

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
     "name": "gitbook-plugin-colorbrewer-picker",
     "description": "Gitbook plugin to include js in templates",
-    "main": "index.js",
     "version": "0.0.7",
     "engines": {
         "gitbook": "*"


### PR DESCRIPTION
Hello,

We will soon release [GitBook v3](https://github.com/GitbookIO/gitbook).
The plugins API has been updated, as you will see [in the GitBook 3 documentation](http://toolchain.gitbook.com/).

I'm in charge of reviewing the existing plugins for maintaining the compatibility with this new version.
In this version, the hooks used for this plugin will not be supported, since we are relying a lot more on the templating system to extend the books HTML.

The proposed PR has been tested with the new version.
Let me know if you have any remarks regarding what is done, and don't forget to publish a new version if you merge it :)

Your new version's `package.json` must reflect the gitbook engine update:

``` JSON
"engines": {
    "gitbook": ">=3.0.0-pre.0"
}
```

Kind regards,
Johan
